### PR TITLE
fix(webextension): add worker-src: self blob to CSP

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
 [build]
   command = "yarn run build && yarn run website"
   functions = "functions"
-  publish = "packages/textchecker-element/public-dist"
+  publish = "packages/textchecker-element/dist"
 
   ## Uncomment to use this redirect for Single Page Applications like create-react-app.
   ## Not needed for static site generators.

--- a/packages/webextension/app/manifest.json
+++ b/packages/webextension/app/manifest.json
@@ -41,6 +41,7 @@
     "webRequestBlocking",
     "<all_urls>"
   ],
+  "content_security_policy": "script-src 'self'; object-src 'self'; worker-src 'self' blob:",
   "__firefox__applications": {
     "gecko": {
       "id": "editor@textlint.github.io"


### PR DESCRIPTION
Firefox Webextension require worker-src directive in background pages for launching WebWorker in background.

fix #37 
fix #38 