### PR TITLE
add dep for script-compiler

### DIFF
--- a/packages/@textlint/script-compiler/package.json
+++ b/packages/@textlint/script-compiler/package.json
@@ -60,6 +60,8 @@
     "@textlint/runtime-helper": "^0.12.0",
     "@textlint/script-parser": "^0.12.0",
     "@textlint/types": "^12.0.0",
+    "@textlint/textlint-plugin-markdown": "^12.0.0",
+    "@textlint/textlint-plugin-text": "^12.0.0",
     "babel-loader": "^8.2.2",
     "babel-plugin-static-fs": "^3.0.0",
     "meow": "^9.0.0",


### PR DESCRIPTION
`@textlint/textlint-plugin-text` must be added into `dependencies`. Otherwise we will get the following error when execute `textlint-script-compiler` command:
```
ReferenceError: Failed to load textlint's plugin module: "@textlint/text" is not found.
See FAQ: https://github.com/textlint/textlint/blob/master/docs/faq/failed-to-load-textlints-module.md

    at TextLintModuleResolver.resolvePluginPackageName (/Users/chenyulu/code/note-app/node_modules/@textlint/config-loader/lib/textlint-module-resolver.js:127:15)
    at /Users/chenyulu/code/note-app/node_modules/@textlint/config-loader/lib/loader.js:13:49
    at Array.forEach (<anonymous>)
    at Object.loadPlugins (/Users/chenyulu/code/note-app/node_modules/@textlint/config-loader/lib/loader.js:12:23)
    at Object.loadPackagesFromRawConfig (/Users/chenyulu/code/note-app/node_modules/@textlint/config-loader/lib/config-loader.js:31:23)
    at Object.loadConfig (/Users/chenyulu/code/note-app/node_modules/@textlint/config-loader/lib/config-loader.js:84:26)
    at /Users/chenyulu/code/note-app/node_modules/@textlint/script-compiler/lib/compiler.js:134:48
    at Generator.next (<anonymous>)
    at /Users/chenyulu/code/note-app/node_modules/@textlint/script-compiler/lib/compiler.js:27:71
    at new Promise (<anonymous>)
```