### PR TITLE
fix(script-compiler): require ext in TextlintWorkerCommandLint

### DIFF
--- a/packages/@textlint/script-compiler/src/CodeGenerator/worker-codegen.ts
+++ b/packages/@textlint/script-compiler/src/CodeGenerator/worker-codegen.ts
@@ -5,6 +5,7 @@ import { TextlintScriptMetadata } from "@textlint/script-parser";
 export type TextlintWorkerCommandLint = {
     command: "lint";
     text: string;
+    ext: string;
     ruleId?: string;
 };
 export type TextlintWorkerCommandFix = {


### PR DESCRIPTION
looks like `TextlintWorkerCommandLint` requires `exp`

https://github.com/textlint/editor/blob/e77217f705e4a8aa5763b83866d593ec70a9c089/packages/%40textlint/script-compiler/src/CodeGenerator/worker-codegen.ts#L128-L129