### PR TITLE
feat(script-compiler): add id property in lint and fix messages

### DIFF
--- a/packages/@textlint/script-compiler/README.md
+++ b/packages/@textlint/script-compiler/README.md
@@ -49,9 +49,11 @@ worker.addEventListener('message', function (event) {
                 }
             },
         });
+        const id = crypto.randomUUID();
         setTimeout(() => {
             // lint
             worker.postMessage({
+                id,
                 command: "lint",
                 text: "お刺身が食べれない",
                 ext: ".md"

--- a/packages/@textlint/script-compiler/example/webindex.html
+++ b/packages/@textlint/script-compiler/example/webindex.html
@@ -22,8 +22,10 @@
                     }
                 },
             });
+            const id = crypto.randomUUID();
             setTimeout(() => {
                 worker.postMessage({
+                    id,
                     command: "lint",
                     text: "お刺身が食べれない",
                     ext: ".md"

--- a/packages/@textlint/script-compiler/src/CodeGenerator/worker-codegen.ts
+++ b/packages/@textlint/script-compiler/src/CodeGenerator/worker-codegen.ts
@@ -2,13 +2,16 @@ import { TextlintConfigDescriptor } from "@textlint/config-loader";
 import type { TextlintFixResult, TextlintResult } from "@textlint/types";
 import { TextlintScriptMetadata } from "@textlint/script-parser";
 
+export type MessageId = string;
 export type TextlintWorkerCommandLint = {
+    id?: MessageId;
     command: "lint";
     text: string;
     ext: string;
     ruleId?: string;
 };
 export type TextlintWorkerCommandFix = {
+    id?: MessageId;
     command: "fix";
     text: string;
     ext: string;
@@ -28,10 +31,12 @@ export type TextlintWorkerCommandResponseInit = {
     metadata: TextlintScriptMetadata;
 };
 export type TextlintWorkerCommandResponseLint = {
+    id: MessageId | undefined;
     command: "lint:result";
     result: TextlintResult;
 };
 export type TextlintWorkerCommandResponseFix = {
+    id: MessageId | undefined;
     command: "fix:result";
     result: TextlintFixResult;
 };
@@ -130,6 +135,7 @@ self.addEventListener('message', (event) => {
                 ext: data.ext,
             }).then(result => {
                 return self.postMessage({
+                    id: data.id,
                     command: "lint:result",
                     result
                 });
@@ -143,6 +149,7 @@ self.addEventListener('message', (event) => {
                 ext: data.ext,
             }).then(result => {
                 return self.postMessage({
+                    id: data.id,
                     command: "fix:result",
                     result
                 });


### PR DESCRIPTION
ref: #72 

- add optional `id` in lint/fix messages at script-compiler
  - if command message has `id`, response message always have same `id`
  - if command message does not have `id`, response message has `id` property but it is just `undefined`
  - mandating `id` is out of scope for this PR
- add `id` where Textlint worker is used, using `crypto.randomUUID()`