### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,9 @@ jobs:
         os: [ ubuntu-latest, windows-latest ]
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           cache: "yarn"
           node-version: ${{ matrix.node-version }}


### PR DESCRIPTION
https://github.com/textlint/editor/actions/runs/8541187057

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-node@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

In GitHub Actions, Node.js 16 is deprecated: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
Therefore, I update Actions to version using Node.js 20.