### PR TITLE
fix: add Node.js 22 to CI test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [ 18, 20 ]
+        node-version: [ 18, 20, 22 ]
         os: [ ubuntu-latest, windows-latest ]
     steps:
       - name: checkout


### PR DESCRIPTION
https://github.com/nodejs/Release
Node.js 22 is LTS now.
Therefore, I add it to CI `test`.