### PR TITLE
fix: fix steps in CI test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,11 +22,9 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Install
         run: yarn install
-      - name: Build
-        run: yarn run build
+      - name: Test
+        run: yarn test
       - name: Build webextension (Chrome)
         run: npm run dist chrome
         if: matrix.os == 'ubuntu-latest'
         working-directory: packages/webextension
-      - name: Test
-        run: yarn test


### PR DESCRIPTION
https://github.com/textlint/editor/blob/00dba75cfdf30022b18d5a6a35c22e2763b50b22/package.json#L31-L32

In CI `test,` `yarn build` runs twice because `yarn test` includes `yarn build`.
Therefore, I change steps in CI `test` to `yarn install` -> `yarn test` -> `npm run dist chrome`.