### PR TITLE
fix: remove a unused attribute from install-dialog.html

### DIFF
--- a/packages/webextension/app/pages/install-dialog.html
+++ b/packages/webextension/app/pages/install-dialog.html
@@ -219,7 +219,7 @@
     </style>
 </head>
 <body>
-<div A id="root">
+<div id="root">
 
 </div>
 <script src="../scripts/install-dialog.js"></script>


### PR DESCRIPTION
In `install-dialog.html`, the `A` attribute of the `root` div appears to be unused.
Therefore, I remove it.