### PR TITLE
fix: Chrome extension Manifest v3 support for webextension

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+        with:
+          submodules: true
       - name: setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
@@ -24,6 +26,10 @@ jobs:
         run: yarn install
       - name: Test
         run: yarn test
+      - name: Apply patch
+        run: patch -p1 < diff.patch
+        if: matrix.os == 'ubuntu-latest'
+        working-directory: packages/webextension
       - name: Build webextension (Chrome)
         run: npm run dist chrome
         if: matrix.os == 'ubuntu-latest'

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "packages/webextension/comlink-extension"]
+	path = packages/webextension/comlink-extension
+	url = https://github.com/samdenty/comlink-extension.git

--- a/packages/webextension/README.md
+++ b/packages/webextension/README.md
@@ -8,6 +8,9 @@ textlint editor
     yarn install 
     yarn run build
 
+    # on this dir
+    patch -p1 < diff.patch
+
 ### Install textlint scripts
 
 textlint editor install your textlint scripts like Greasemonkey.

--- a/packages/webextension/app/scripts/InstalledApp/StateContext.tsx
+++ b/packages/webextension/app/scripts/InstalledApp/StateContext.tsx
@@ -1,8 +1,8 @@
 // src/contexts/AppStateContext.tsx
 import React, { Dispatch, SetStateAction, useContext, useState } from "react";
-import { browser } from "webextension-polyfill-ts";
+import browser from "webextension-polyfill";
 import * as Comlink from "comlink";
-import { forward } from "comlink-extension";
+import { forward } from "../../../comlink-extension/src";
 import { BackgroundToPopupObject } from "../background";
 const { port1, port2 } = new MessageChannel();
 forward(port1, browser.runtime.connect());

--- a/packages/webextension/app/scripts/background.ts
+++ b/packages/webextension/app/scripts/background.ts
@@ -1,5 +1,5 @@
-import { browser } from "webextension-polyfill-ts";
-import { createBackgroundEndpoint, isMessagePort } from "comlink-extension";
+import browser from "webextension-polyfill";
+import { createBackgroundEndpoint, isMessagePort } from "../../comlink-extension/src";
 import * as Comlink from "comlink";
 import { createTextlintWorker } from "./background/textlint";
 import { keyOfScript, openDatabase, Script } from "./background/database";

--- a/packages/webextension/app/scripts/background/onTextlintWorker.ts
+++ b/packages/webextension/app/scripts/background/onTextlintWorker.ts
@@ -1,4 +1,4 @@
-import { browser } from "webextension-polyfill-ts";
+import browser from "webextension-polyfill";
 
 const isTextlintWorkerUrl = (urlString: string): boolean => {
     try {

--- a/packages/webextension/app/scripts/contentScript.ts
+++ b/packages/webextension/app/scripts/contentScript.ts
@@ -1,6 +1,6 @@
 import { LintEngineAPI } from "textchecker-element";
-import { browser } from "webextension-polyfill-ts";
-import { createEndpoint } from "comlink-extension";
+import browser from "webextension-polyfill";
+import { createEndpoint } from "../../comlink-extension/src";
 import * as Comlink from "comlink";
 import type { BackgroundToContentObject } from "./background";
 import { nonRandomKey } from "./shared/page-contents-shared";
@@ -14,7 +14,7 @@ rawPort.onMessage.addListener((event) => {
         logger.log("[ContentScript]", "boot event received");
         // Inject page-script
         try {
-            const script = browser.extension.getURL("scripts/pageScript.js");
+            const script = browser.runtime.getURL("scripts/pageScript.js");
             const pageScript = document.createElement("script");
             pageScript.src = script;
             document.body.append(pageScript);

--- a/packages/webextension/app/scripts/install-dialog.tsx
+++ b/packages/webextension/app/scripts/install-dialog.tsx
@@ -1,7 +1,7 @@
-import { createEndpoint } from "comlink-extension";
+import { createEndpoint } from "../../comlink-extension/src";
 import * as Comlink from "comlink";
 import type { BackgroundToPopupObject } from "./background";
-import { browser } from "webextension-polyfill-ts";
+import browser from "webextension-polyfill";
 import { parseMetadata, TextlintScriptMetadata } from "@textlint/script-parser";
 import { logger } from "./utils/logger";
 import * as React from "react";

--- a/packages/webextension/diff.patch
+++ b/packages/webextension/diff.patch
@@ -1,0 +1,22 @@
+diff --git a/comlink-extension/src/adapter.ts b/comlink-extension/src/adapter.ts
+index 11038b3..2b50a15 100644
+--- a/comlink-extension/src/adapter.ts
++++ b/comlink-extension/src/adapter.ts
+@@ -27,7 +27,7 @@ export function createEndpoint(
+ 
+   function serialize(data: any): void {
+     if (Array.isArray(data)) {
+-      data.forEach((value, i) => {
++      data.forEach((value) => {
+         serialize(value);
+       });
+     } else if (data && typeof data === "object") {
+@@ -97,7 +97,7 @@ export function createEndpoint(
+   }
+ 
+   return {
+-    postMessage: (message, transfer: MessagePort[]) => {
++    postMessage: (message) => {
+       serialize(message);
+       port.postMessage(message);
+     },

--- a/packages/webextension/package.json
+++ b/packages/webextension/package.json
@@ -15,6 +15,7 @@
         "@types/reach__router": "^1.3.6",
         "@types/react": "^17.0.0",
         "@types/react-dom": "^17.0.0",
+        "@types/webextension-polyfill": "^0.10.1",
         "copy-webpack-plugin": "^12.0.2",
         "css-loader": "^6.11.0",
         "path-browserify": "^1.0.1",
@@ -36,8 +37,7 @@
         "@textlint/script-parser": "^0.17.0",
         "@textlint/types": "^14.0.4",
         "codemirror": "^5.59.2",
-        "comlink": "^4.3.0",
-        "comlink-extension": "^1.0.8",
+        "comlink": "^4.4.1",
         "enable-webcomponents-in-content-scripts": "^1.0.7",
         "idb": "^5.0.4",
         "minimatch": "^3.0.4",
@@ -45,6 +45,6 @@
         "react-codemirror2": "^8.0.0",
         "react-dom": "^17.0.2",
         "textchecker-element": "^0.17.0",
-        "webextension-polyfill-ts": "^0.25.0"
+        "webextension-polyfill": "^0.10.0"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4306,6 +4306,11 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
 
+"@types/webextension-polyfill@^0.10.1":
+  version "0.10.7"
+  resolved "https://registry.yarnpkg.com/@types/webextension-polyfill/-/webextension-polyfill-0.10.7.tgz#de059250599733a60ed26c8a0c81e21e11183b90"
+  integrity sha512-10ql7A0qzBmFB+F+qAke/nP1PIonS0TXZAOMVOxEUsm+lGSW6uwVcISFNa0I4Oyj0884TZVWGGMIWeXOVSNFHw==
+
 "@types/webpack@^5.28.5":
   version "5.28.5"
   resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-5.28.5.tgz#0e9d9a15efa09bbda2cef41356ca4ac2031ea9a2"
@@ -5615,17 +5620,10 @@ combined-stream@^1.0.8:
   dependencies:
     delayed-stream "~1.0.0"
 
-comlink-extension@^1.0.8:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/comlink-extension/-/comlink-extension-1.0.8.tgz#ce3c5187812d1cce26062257d933da3cfd9340c3"
-  integrity sha512-iFTvW79mu98SReqIxkLy5ll9T5MNbtemSUfI+KbotVXm8eGS5i45CsFpG1lr41FQAJoWY/Hq1hc8ubxJkVa57g==
-  dependencies:
-    webextension-polyfill-ts "^0.19.0"
-
-comlink@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/comlink/-/comlink-4.3.0.tgz#80b3366baccd87897dab3638ebfcfae28b2f87c7"
-  integrity sha512-mu4KKKNuW8TvkfpW/H88HBPeILubBS6T94BdD1VWBXNXfiyqVtwUCVNO1GeNOBTsIswzsMjWlycYr+77F5b84g==
+comlink@^4.4.1:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/comlink/-/comlink-4.4.2.tgz#cbbcd82742fbebc06489c28a183eedc5c60a2bca"
+  integrity sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==
 
 comma-separated-tokens@^1.0.0:
   version "1.0.8"
@@ -12601,29 +12599,10 @@ webcomponentsjs-custom-element-v0@^1.0.1:
   resolved "https://registry.yarnpkg.com/webcomponentsjs-custom-element-v0/-/webcomponentsjs-custom-element-v0-1.0.2.tgz#3cd13aba3222680b1b1da823719c8d3cc3d594ee"
   integrity sha512-Xlaa+HQw6pR9+hCxQKy41m12V0M4kEGmsvDVAF98nidSAR/X1fqmWHjb5cszD8RRLhWQjrCOFb7QQNipfsN5mg==
 
-webextension-polyfill-ts@^0.19.0:
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/webextension-polyfill-ts/-/webextension-polyfill-ts-0.19.0.tgz#3e3a059c656936c853b47d2a57bf114c615c1e1e"
-  integrity sha512-VcA7bdf0dzUc8JXQwQU+spSUTV0Gc0Y7VPsdrEFLbuTxJluC4xBoKVWtfUXRqykVfDvFsfo591+p1MmPSJezsw==
-  dependencies:
-    webextension-polyfill "^0.6.0"
-
-webextension-polyfill-ts@^0.25.0:
-  version "0.25.0"
-  resolved "https://registry.yarnpkg.com/webextension-polyfill-ts/-/webextension-polyfill-ts-0.25.0.tgz#fff041626365dbd0e29c40b197e989a55ec221ca"
-  integrity sha512-ikQhwwHYkpBu00pFaUzIKY26I6L87DeRI+Q6jBT1daZUNuu8dSrg5U9l/ZbqdaQ1M/TTSPKeAa3kolP5liuedw==
-  dependencies:
-    webextension-polyfill "^0.7.0"
-
-webextension-polyfill@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/webextension-polyfill/-/webextension-polyfill-0.6.0.tgz#1afd925f3274a0d4848083579b9c0b649a5c6763"
-  integrity sha512-PlYwiX8e4bNZrEeBFxbFFsLtm0SMPxJliLTGdNCA0Bq2XkWrAn2ejUd+89vZm+8BnfFB1BclJyCz3iKsm2atNg==
-
-webextension-polyfill@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/webextension-polyfill/-/webextension-polyfill-0.7.0.tgz#0df1120ff0266056319ce1a622b09ad8d4a56505"
-  integrity sha512-su48BkMLxqzTTvPSE1eWxKToPS2Tv5DLGxKexLEVpwFd6Po6N8hhSLIvG6acPAg7qERoEaDL+Y5HQJeJeml5Aw==
+webextension-polyfill@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/webextension-polyfill/-/webextension-polyfill-0.10.0.tgz#ccb28101c910ba8cf955f7e6a263e662d744dbb8"
+  integrity sha512-c5s35LgVa5tFaHhrZDnr3FpQpjj1BB+RXhLTYUxGqBVN460HkbM8TBtEqdXWbpTKfzwCcjAZVF7zXCYSKtcp9g==
 
 webidl-conversions@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
Fix https://github.com/textlint/editor/issues/33

I fix `webextension` to support Chrome extension Manifest v3.
I fix to get scripts from the service worker and run workers with the content script.

Also, for `comlink-extension`, https://github.com/samdenty/comlink-extension/pull/4 included diff where `webextension-polyfill-ts` was replaced with `webextension-polyfill` .
However, it hasn't been released.
Therefore, `webextension` references the latest commit of `comlink-extension` using the git submodule.