### PR TITLE
fix(script-compiler): add "mainFields" resolution to fix module parsing issue

### DIFF
--- a/packages/@textlint/script-compiler/src/compiler.ts
+++ b/packages/@textlint/script-compiler/src/compiler.ts
@@ -121,7 +121,7 @@ export const createWebpackConfig = ({
             fallback: {
                 fs: false
             },
-            // "module" filed should be ignored
+            // "module" field should be ignored
             // type=commonjs and "module" field is not compatible
             mainFields: ["browser", "main"]
         },

--- a/packages/@textlint/script-compiler/src/compiler.ts
+++ b/packages/@textlint/script-compiler/src/compiler.ts
@@ -120,7 +120,10 @@ export const createWebpackConfig = ({
         resolve: {
             fallback: {
                 fs: false
-            }
+            },
+            // "module" filed should be ignored
+            // type=commonjs and "module" field is not compatible
+            mainFields: ["browser", "main"]
         },
         performance: {
             hints: false


### PR DESCRIPTION
Fixes #108

## Summary

This PR fixes the issue where `@textlint/script-compiler` fails to compile packages that depend on recent `@textlint/module-interop`.

## Problem

The issue occurs because webpack prioritizes the `module` field in package.json resolution, which leads to importing ES modules in a CommonJS context. This causes parsing errors when the `module` field points to ES module files but webpack expects CommonJS.

## Solution

Added `mainFields: ["browser", "main"]` to webpack's resolve configuration to ignore the `module` field and prioritize `browser` and `main` fields instead. This ensures compatibility with CommonJS type compilation.

## Changes

- Modified `packages/@textlint/script-compiler/src/compiler.ts` to add `mainFields` configuration in webpack resolve options
- Added comment explaining why the `module` field should be ignored for CommonJS compatibility

## Testing

This change fixes the compilation error with `textlint-rule-preset-ja-technical-writing@10.0.2` that depends on `@textlint/module-interop@^14.4.0`.