### PR TITLE
fix: replace decode-entity.browser.js for Web Workers

### DIFF
--- a/packages/@textlint/script-compiler/src/compiler.ts
+++ b/packages/@textlint/script-compiler/src/compiler.ts
@@ -97,6 +97,11 @@ export const createWebpackConfig = ({
             new webpack.NormalModuleReplacementPlugin(/^node:/, (resource) => {
                 resource.request = resource.request.replace(/^node:/, "");
             }),
+            // parse-entities@2.0.0 for Web Worker
+            new webpack.NormalModuleReplacementPlugin(
+                /parse-entities\/decode-entity\.browser\.js/,
+                require.resolve("parse-entities/decode-entity.js")
+            ),
             // Node.js polyfill
             new NodePolyfillPlugin({})
         ],


### PR DESCRIPTION
Hello.

I've found what appears to be a small bug, so I'd like to report it.

## Problem

In `textlint/editor`, if a named entity reference (e.g. `&gt;`) is entered, the error "document is not defined" occurs.

Numeric entity references, however, work fine.

Screen Shot:

<img width="848" height="671" alt="image" src="https://github.com/user-attachments/assets/b8a268f7-f739-4e79-9a3b-286a520c66c2" />

Error message and Stacktrace:

```txt
Failed to parse text by plugin: @textlint/markdown
Please report this error with the content to plugin author.
ReferenceError: document is not defined
 at e.exports [as default] (https://textlint-editor.netlify.app/textlint-worker.js:34:60556)
 at f (https://textlint-editor.netlify.app/textlint-worker.js:34:20587)
 at A (https://textlint-editor.netlify.app/textlint-worker.js:66:49848)
 at D (https://textlint-editor.netlify.app/textlint-worker.js:66:49790)
 at Object.write (https://textlint-editor.netlify.app/textlint-worker.js:66:49398)
 at o (https://textlint-editor.netlify.app/textlint-worker.js:14:26192)
 at e.exports (https://textlint-editor.netlify.app/textlint-worker.js:14:27118)
 at e.exports (https://textlint-editor.netlify.app/textlint-worker.js:26:328)
 at e.exports (https://textlint-editor.netlify.app/textlint-worker.js:66:11445)
 at Parser (https://textlint-editor.netlify.app/textlint-worker.js:34:84643)
```

Source:

<img width="668" height="305" alt="image" src="https://github.com/user-attachments/assets/1fdee2c4-308c-463f-bd0f-183cc9fb9ac6" />

This error seems to originate from [`parse-entities`](https://www.npmjs.com/package/parse-entities).
The latest version of parse-entities is 4.0.2, but `textlint/editor` currently uses 2.0.0, which appears to switch between the browser and non-browser versions.

`textlint/editor` imports the browser version of `parse-entities`, which depends on `document`. However, since `textlint/editor` runs the relevant code inside a Web Worker, `document` is not available, leading to the error.

## Proposed Solution

Possible solutions could include:

- Use the non-browser version of `parse-entities`
- Upgrading to a newer version of `parse-entities`
- Switching to a different library

For this pull request, I modified `src/compiler.ts` in `@textlint/script-compiler` to use the non-browser version, and added a Webpack plugin configuration.

With this change, we confirmed that the error no longer occurs when entering named entity references.
That said, we haven’t yet conducted extensive testing.